### PR TITLE
Finalize asyncpg migration and update API endpoints

### DIFF
--- a/app/api/v1/endpoints/priorities.py
+++ b/app/api/v1/endpoints/priorities.py
@@ -18,8 +18,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
 
             current_user = await get_current_active_user(request)
 
-            pool = await get_db()
-            async with pool.acquire() as connection:
+            async with get_db() as connection:
                 skip = (page - 1) * size
                 priorities = await PriorityService.get_priorities(
                     connection, current_user.key, skip, size
@@ -47,7 +46,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
                             if page > 1
                             else None
                         ),
-                    ).dict()
+                    ).model_dump()
                 )
 
         except Exception as e:

--- a/app/api/v1/endpoints/todos.py
+++ b/app/api/v1/endpoints/todos.py
@@ -30,8 +30,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
             current_user = await get_current_active_user(request)
 
             # Get database connection
-            pool = await get_db()
-            async with pool.acquire() as connection:
+            async with get_db() as connection:
                 skip = (page - 1) * size
                 todos = await TodoService.get_todos(
                     connection,
@@ -60,7 +59,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
                         prev_link=(
                             f"/todos?page={page - 1}&size={size}" if page > 1 else None
                         ),
-                    ).dict()
+                    ).model_dump()
                 )
 
         except Exception as e:
@@ -75,8 +74,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
             key = request.match_info["key"]
             current_user = await get_current_active_user(request)
 
-            pool = await get_db()
-            async with pool.acquire() as connection:
+            async with get_db() as connection:
                 todo = await TodoService.get_todo_by_key(
                     connection, key, current_user.key
                 )
@@ -85,7 +83,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
                         {"detail": f"Todo with key {key} not found"}, status=404
                     )
 
-                return web.json_response(TodoResponse(**todo).dict())
+                return web.json_response(TodoResponse(**todo).model_dump())
 
         except Exception as e:
             return web.json_response(
@@ -100,12 +98,11 @@ def setup_routes(app: web.Application, cors, prefix: str):
             data = await request.json()
             todo_create = TodoCreate(**data)
 
-            pool = await get_db()
-            async with pool.acquire() as connection:
+            async with get_db() as connection:
                 todo = await TodoService.create_todo(
                     connection, todo_create, current_user.key
                 )
-                return web.json_response(TodoResponse(**todo).dict(), status=201)
+                return web.json_response(TodoResponse(**todo).model_dump(), status=201)
 
         except ValueError as e:
             return web.json_response({"detail": str(e)}, status=400)
@@ -123,8 +120,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
             data = await request.json()
             todo_update = TodoUpdate(**data)
 
-            pool = await get_db()
-            async with pool.acquire() as connection:
+            async with get_db() as connection:
                 todo = await TodoService.update_todo(
                     connection, key, todo_update, current_user.key
                 )
@@ -133,7 +129,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
                         {"detail": f"Todo with key {key} not found"}, status=404
                     )
 
-                return web.json_response(TodoResponse(**todo).dict())
+                return web.json_response(TodoResponse(**todo).model_dump())
 
         except ValueError as e:
             return web.json_response({"detail": str(e)}, status=400)
@@ -150,8 +146,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
             current_user = await get_current_active_user(request)
             data = await request.json()
 
-            pool = await get_db()
-            async with pool.acquire() as connection:
+            async with get_db() as connection:
                 todo = await TodoService.patch_todo(
                     connection, key, data, current_user.key
                 )
@@ -160,7 +155,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
                         {"detail": f"Todo with key {key} not found"}, status=404
                     )
 
-                return web.json_response(TodoResponse(**todo).dict())
+                return web.json_response(TodoResponse(**todo).model_dump())
 
         except ValueError as e:
             return web.json_response({"detail": str(e)}, status=400)
@@ -176,8 +171,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
             key = request.match_info["key"]
             current_user = await get_current_active_user(request)
 
-            pool = await get_db()
-            async with pool.acquire() as connection:
+            async with get_db() as connection:
                 success = await TodoService.delete_todo(
                     connection, key, current_user.key
                 )

--- a/app/api/v1/endpoints/token.py
+++ b/app/api/v1/endpoints/token.py
@@ -16,8 +16,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
             data = await request.json()
             user_login = UserLogin(**data)
 
-            pool = await get_db()
-            async with pool.acquire() as connection:
+            async with get_db() as connection:
                 token = await AuthService.authenticate(
                     connection, user_login.username, user_login.password
                 )
@@ -27,7 +26,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
                     )
 
                 return web.json_response(
-                    Token(access_token=token, token_type="bearer").dict()
+                    Token(access_token=token, token_type="bearer").model_dump()
                 )
 
         except Exception as e:

--- a/app/api/v1/endpoints/user.py
+++ b/app/api/v1/endpoints/user.py
@@ -16,10 +16,9 @@ def setup_routes(app: web.Application, cors, prefix: str):
             data = await request.json()
             user_create = UserCreate(**data)
 
-            pool = await get_db()
-            async with pool.acquire() as connection:
+            async with get_db() as connection:
                 user = await UserService.create_user(connection, user_create)
-                return web.json_response(UserResponse(**user).dict(), status=201)
+                return web.json_response(UserResponse(**user).model_dump(), status=201)
 
         except ValueError as e:
             return web.json_response({"detail": str(e)}, status=400)
@@ -33,7 +32,7 @@ def setup_routes(app: web.Application, cors, prefix: str):
         """Get current user information."""
         try:
             current_user = await get_current_active_user(request)
-            return web.json_response(UserResponse(**current_user.__dict__).dict())
+            return web.json_response(UserResponse(**current_user.model_dump()).model_dump())
 
         except Exception as e:
             return web.json_response(

--- a/app/database.py
+++ b/app/database.py
@@ -1,5 +1,6 @@
 # app/database.py
 import asyncpg
+from contextlib import asynccontextmanager
 from app.core.config import settings
 from typing import Optional
 
@@ -30,8 +31,9 @@ async def close_pool():
         _pool = None
 
 
+@asynccontextmanager
 async def get_db():
-    """Get a database connection from the pool."""
+    """Yield a database connection from the pool."""
     pool = await get_pool()
     async with pool.acquire() as connection:
         yield connection

--- a/app/schemas/token.py
+++ b/app/schemas/token.py
@@ -1,12 +1,9 @@
 from pydantic import BaseModel
-from datetime import datetime
 
 
 class Token(BaseModel):
     access_token: str
-    token_type: str
-    expires_at: datetime
-    user_key: str
+    token_type: str = "bearer"
 
 
 class TokenData(BaseModel):

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -25,15 +25,16 @@ class UserService:
         user_key = str(uuid.uuid4())
         user_data = await connection.fetchrow(
             """
-            INSERT INTO users (key, username, email, hashed_password, is_active)
-            VALUES ($1, $2, $3, $4, $5)
-            RETURNING id, key, username, email, hashed_password, is_active, created_at, updated_at
+            INSERT INTO users (key, name, username, email, hashed_password, is_active)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING id, key, name, username, email, hashed_password, is_active, created_at, updated_at
         """,
             user_key,
+            user.name,
             user.username,
             user.email,
             hashed_password,
-            True,
+            user.is_active,
         )
 
         return dict(user_data)


### PR DESCRIPTION
## Summary
- Convert `get_db` helper to an async context manager and update callers
- Drop SQLAlchemy user model usage and rely on Pydantic schemas in auth middleware
- Simplify token schema and ensure user creation stores name field

## Testing
- `pytest -q` *(fails: ImportError cannot import name 'Base' from 'app.database')*


------
https://chatgpt.com/codex/tasks/task_e_689da8f4d490832baff4878fec30adff